### PR TITLE
Client.js: Add ending character at the end of the message

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -101,7 +101,7 @@ class Client extends BaseClient {
 		let msg_p = new ChatMessage();
 		msg_p.fields.player_id.value = this.localPlayerId;
 		msg_p.fields.chat_type.value = _type;
-		msg_p.fields.chat_message.value = msg;
+		msg_p.fields.chat_message.value = msg + '\x00';
 
 		let send_packet = msg_p.encodeInfos();
 		send_packet.writeUInt8(17, 0);


### PR DESCRIPTION
Packets that are sent to the server must contain a null ending character to indicate the end of the message.

Pique handles this already due to the way its designed and SpadesX only very recently started handling this but as it is a client (or in this case a library) issue this should be handled here.